### PR TITLE
Update issue templates and include Sweep AI template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: 🐛 Bug report
+description: Report a bug currently impacting tsml-eval.
+title: "[BUG] "
+labels: ["bug"]
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### You can see if he bug has already been addressed by searching
+      through the open and closed [issues](https://github.com/time-series-machine-learning/tsml-eval/issues?q=is%3Aissue).
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: >
+      A clear and concise description of what the bug is.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps/Code to reproduce the bug
+    description: |
+      Please include a [minimal reproducible example](https://stackoverflow.com/help/mcve) so users can reproduce the error when running it. Be as succinct as possible, and do not depend on external data files.
+
+      If the code is too long, feel free to put it in a public [gist](https://gist.github.com) and link it in the issue.
+    placeholder: |
+      ```python
+      Your code here. placing your code between three backticks will format it like the above example.
+      ```
+- type: textarea
+  attributes:
+    label: Expected results
+    description: >
+      Please provide a clear and concise description of the expected results or paste the correct output if available.
+    placeholder: >
+      For example: No error is thrown, or y_name1 == y_name2.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual results
+    description: |
+      Please provide a clear and concise description of the actual seen results or paste the incorrect output if available.
+
+      If you observe an error, please paste the error message including the full traceback of the exception. For instance the code example above raises the following exception:
+    placeholder: |
+      ```python-traceback
+      Place traceback error here if applicable. If your issue has no traceback, please describe the observed output without formatting.
+      ```
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: "\u2709\uFE0F Email"
+    url: https://mailxto.com/gj5bni0yvt
+    about: Send an email to the TSML developers at M.B.Middlehurst@gmail.com. Checked periodically.
+  - name: "\U0001F310 TSC Webpage"
+    url: https://www.timeseriesclassification.com/
+    about: The TSML research group and TSC dataset archive website.

--- a/.github/ISSUE_TEMPLATE/doc_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.yml
@@ -1,0 +1,18 @@
+name: 📖 Documentation improvement
+description: Create a report to help us improve the tsml-eval documentation.
+title: "[DOC] "
+labels: ["documentation"]
+
+body:
+- type: textarea
+  attributes:
+    label: Describe the issue linked to the documentation
+    description: >
+      Tell us about the confusion introduced in the documentation.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Suggest a potential alternative/fix
+    description: >
+      Tell us how we could improve the documentation in this regard.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: ✨ Feature request
+description: Suggest a new algorithm or idea for tsml-eval.
+title: "[ENH] "
+labels: ["enhancement"]
+
+body:
+- type: textarea
+  attributes:
+    label: Describe the feature or idea you want to propose
+    description: >
+      Is your feature request related to a problem? Please describe. If relevant, you
+      should link to a paper or other reference.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe your proposed solution
+    description: >
+      A clear and concise description of what you want to happen, ideally taking into
+      consideration the existing package design, classes and methods.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Other comments and alternatives considered
+    description: >
+      Add any other context or comments, or alternative solutions relating to the
+      problem here.

--- a/.github/ISSUE_TEMPLATE/other_issue.yml
+++ b/.github/ISSUE_TEMPLATE/other_issue.yml
@@ -1,0 +1,20 @@
+name: 🔧 Other issue
+description: Other issue categories do not fit.
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      If the issue is maintenance related (i.e. CI), please start the title with [MNT]
+      and add the maintenance tag.
+- type: textarea
+  attributes:
+    label: Describe the issue
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Suggest a potential alternative/fix.
+- type: textarea
+  attributes:
+    label: Additional context or comments

--- a/.github/ISSUE_TEMPLATE/sweep.yml
+++ b/.github/ISSUE_TEMPLATE/sweep.yml
@@ -1,0 +1,30 @@
+name: 🤖 Sweep AI
+description: Write a prompt for the Sweep AI bot to create a pull request from.
+title: 'Sweep: '
+labels: ["sweep"]
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### See the [Sweep AI docs](https://docs.sweep.dev/) for more information.
+- type: textarea
+  attributes:
+    label: Details
+    description: >
+      Tell Sweep where and what to edit and provide enough context for a new developer
+      to the codebase.
+    placeholder: |
+        Bugs: The bug might be in ... file. Here are the logs: ...
+        Features: the new endpoint should use the ... class from ... file because it contains ... logic.
+        Refactors: We are migrating this function to ... version because ...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Files to change
+    description: Optional but can improve Sweep
+    placeholder: |
+      src/main.py
+      tests/test.py
+    render: Shell

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Thanks for contributing with a pull request!
+Feel free to delete sections the template if they do not apply to the PR.
+-->
+
+#### Reference Issues/PRs
+
+<!--
+i.e. Fixes #1234 or See #3456.
+-->
+
+#### What does this implement/fix? Explain your changes
+
+<!--
+A clear and concise description of what you have implemented.
+-->
+
+#### Any other comments?
+
+<!--
+Please be aware that we are a team of volunteers so patience is necessary.
+-->


### PR DESCRIPTION
Adds issue/PR templates. Allows for [Sweep](https://docs.sweep.dev/) to be used to create PRs using AI (hopefully).