### PR TITLE
[MNT] Edit release workflow

### DIFF
--- a/.github/workflows/pr_precommit.yml
+++ b/.github/workflows/pr_precommit.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.10"
 
-      - uses: tj-actions/changed-files@v46
+      - uses: tj-actions/changed-files@v46.0.1
         id: changed-files
 
       - name: List changed files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,12 @@ jobs:
     needs: test-wheels
     runs-on: ubuntu-24.04
 
+    environment:
+      name: release
+      url: https://pypi.org/p/tsml-eval/
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -103,5 +109,3 @@ jobs:
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Uses trusted publishing instead of GitHub secrets with an API key.