### PR TITLE
Fix compatibility with recent aeon depreciations

### DIFF
--- a/tsml_eval/experiments/experiments.py
+++ b/tsml_eval/experiments/experiments.py
@@ -27,7 +27,7 @@ from aeon.classification import BaseClassifier
 from aeon.clustering import BaseClusterer
 from aeon.forecasting import BaseForecaster
 from aeon.regression.base import BaseRegressor
-from aeon.utils.validation import get_n_cases
+from aeon.utils.validation.collection import get_n_cases
 from sklearn import preprocessing
 from sklearn.base import BaseEstimator, is_classifier, is_regressor
 from sklearn.metrics import (

--- a/tsml_eval/utils/datasets.py
+++ b/tsml_eval/utils/datasets.py
@@ -12,7 +12,7 @@ import shutil
 from os.path import exists
 
 import numpy as np
-from aeon.datasets import load_from_ts_file, write_to_ts_file
+from aeon.datasets import load_from_ts_file, save_to_ts_file
 
 
 def load_experiment_data(
@@ -152,4 +152,4 @@ def save_merged_dataset_splits(
     X = np.concatenate([X_train, X_test], axis=0)
     y = np.concatenate([y_train, y_test], axis=0)
 
-    write_to_ts_file(X, f"{save_path}/{dataset}/", y=y, problem_name=dataset)
+    save_to_ts_file(X, f"{save_path}/{dataset}/", y=y, problem_name=dataset)

--- a/tsml_eval/utils/datasets.py
+++ b/tsml_eval/utils/datasets.py
@@ -152,4 +152,4 @@ def save_merged_dataset_splits(
     X = np.concatenate([X_train, X_test], axis=0)
     y = np.concatenate([y_train, y_test], axis=0)
 
-    save_to_ts_file(X, f"{save_path}/{dataset}/", y=y, problem_name=dataset)
+    save_to_ts_file(X, y, path=f"{save_path}/{dataset}/", problem_name=dataset)


### PR DESCRIPTION
<!--
Thanks for contributing with a pull request!
Feel free to delete sections the template if they do not apply to the PR.
-->

#### Reference Issues/PRs
TSML-eval compatibility following aeon 9bacf03 deprecations.


<!--
i.e. Fixes #1234 or See #3456.
-->

#### What does this implement/fix? Explain your changes
Update imports to use save_to_ts_file and get_n_cases from collections as detailed in old pre-9bacf03 deprecated annotations

<!--
A clear and concise description of what you have implemented.
-->

#### Any other comments?
This is only a fix for aeon main, aeon pip release currently works fine
<!--
Please be aware that we are a team of volunteers so patience is necessary.
-->
