### PR TITLE
[MNT] Exclude the _wip package from distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 recursive-include tsml_eval *.py
-recursive-include tsml_eval/_wip *.csv *.xlsx
 recursive-include tsml_eval/datasets *.ts *.csv *.txt
 recursive-include tsml_eval/publications *.csv *.txt *.md *.ipynb
 recursive-include tsml_eval/testing/_test_eval_files *.csv *.pdf *.pickle
@@ -9,6 +8,7 @@ include MANIFEST.in
 include pyproject.toml
 include README.md
 
+recursive-exclude tsml_eval/_wip *
 recursive-exclude .binder *
 recursive-exclude .github *
 recursive-exclude _tsml_research_resources *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,13 +99,18 @@ repository = "https://github.com/time-series-machine-learning/tsml-eval/"
 file = "LICENSE"
 
 [tool.setuptools.packages.find]
-include = ["tsml_eval"]
+include = ["tsml_eval", "tsml_eval.*"]
+# _wip holds unreleased work-in-progress research code; keep it out of distributions
+exclude = ["tsml_eval._wip", "tsml_eval._wip.*"]
 
 [tool.check-manifest]
 ignore = [
     # Ignore virtual environments in local builds
     ".venv/**",
     "venv/**",
+    # Ignore the work-in-progress package, excluded from distributions
+    "tsml_eval/_wip",
+    "tsml_eval/_wip/**",
     # Ignore local files
     "local/**",
     "examples/generated_results/**",


### PR DESCRIPTION
_wip holds unreleased work-in-progress research code and was being shipped in both the wheel (197 files) and the sdist (237 files), ~2.6MB of the release. Exclude it:

- setuptools packages.find: make subpackage discovery explicit (tsml_eval.*) and exclude tsml_eval._wip[.*] from the wheel.
- MANIFEST.in: drop the _wip data-file include and add a recursive-exclude after the broad "recursive-include tsml_eval *.py" that was pulling the _wip sources into the sdist.
- check-manifest: ignore _wip, which is in version control but now deliberately absent from the sdist, so the release workflow's check-manifest gate still passes.

Verified by diffing built artifacts before and after: nothing besides _wip is removed and nothing is added.

fixes failed manifest on release
Claude-Session: https://claude.ai/code/session_01TqiqMtHqX93wvrgMHRPUeX

<!--
Thanks for contributing with a pull request!
Feel free to delete sections the template if they do not apply to the PR.
-->

#### Reference Issues/PRs

<!--
i.e. Fixes #1234 or See #3456.
-->

#### What does this implement/fix? Explain your changes

<!--
A clear and concise description of what you have implemented.
-->

#### Any other comments?

<!--
Please be aware that we are a team of volunteers so patience is necessary.
-->
