### PR TITLE
[MNT] Install OpenMP on macOS in the release wheel tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macos-14, windows-2022 ]
         python-version: [ "3.12", "3.13", "3.14" ]
@@ -60,6 +61,10 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install OpenMP
+        if: runner.os == 'macOS'
+        run: brew install libomp
 
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
The test-wheels job installs the built wheel with [dev,all_extras], which pulls in xgboost. On macOS arm64 xgboost needs OpenMP at import time, and release.yml never installed it, so the job failed with:

  dlopen(.../xgboost/lib/libxgboost.dylib): Library not loaded:
  @rpath/libomp.dylib ... tried: '/opt/homebrew/opt/libomp/lib/libomp.dylib'
  (no such file)

periodic_tests.yml already has this step, which is why its macOS jobs pass while the release job does not.

Also set fail-fast: false on the matrix, matching periodic_tests.yml. The single macOS 3.12 failure cancelled the other eight jobs, hiding whether Linux and Windows would have passed.


Claude-Session: https://claude.ai/code/session_01TqiqMtHqX93wvrgMHRPUeX

<!--
Thanks for contributing with a pull request!
Feel free to delete sections the template if they do not apply to the PR.
-->

#### Reference Issues/PRs

<!--
i.e. Fixes #1234 or See #3456.
-->

#### What does this implement/fix? Explain your changes

<!--
A clear and concise description of what you have implemented.
-->

#### Any other comments?

<!--
Please be aware that we are a team of volunteers so patience is necessary.
-->
